### PR TITLE
changing docker image path from static to dynamic generated depending our aws zone

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -421,6 +421,11 @@ resource "helm_release" "alb_controller" {
   atomic     = true
   timeout    = 900
 
+  set {
+    name  = "image.repository"
+    value = "602401143452.dkr.ecr.${local.aws_region_name}.amazonaws.com/amazon/aws-load-balancer-controller"
+  }
+
   dynamic "set" {
 
     for_each = {


### PR DESCRIPTION
For example if we have zone restrictions, we are not able to download the Image in the US repository and we need to use our specific zone 

dynamic path generation 

602401143452.dkr.ecr.${local.aws_region_name}.amazonaws.com/amazon/aws-load-balancer-controller"


NOTE: after looking all the forks , I see that this is the best fork that works and I would like to do that improvement . 